### PR TITLE
Fix building with wxWidgets 3.0

### DIFF
--- a/src/pdfreport.cpp
+++ b/src/pdfreport.cpp
@@ -800,13 +800,15 @@ bool PdfReport::FootprintReport(wxWindow* parent, const wxString& library, const
     DryRun=!DryRun;
   } while (!DryRun);
 
-  /* sort the index */
-  wxSortedArrayString SortedIndex(CompareFootprint);
+  wxArrayString SortedIndex;
   for (wxStringToStringHashMap::iterator iter = FootprintIndex.begin(); iter != FootprintIndex.end(); iter++) {
     wxString line = iter->first + wxT(" : ") + iter->second;
     SortedIndex.Add(line);
   }
   FootprintIndex.clear();
+
+  /* sort the index */
+  SortedIndex.Sort(CompareFootprint);
 
   /* print the index */
   progress.Update(++progresspos,wxT("Generating the index"));


### PR DESCRIPTION
wxSortedArray is a 3.1 (currently in development) thing, but in this
particular case using the 3.0-compatible way does not seem to be
of any consequence. #5