### PR TITLE
Correct Exec location in installed .desktop file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ src/tags
 CMakeCache.txt
 CMakeFiles
 Makefile
+kicadlibrarian.desktop

--- a/kicadlibrarian.desktop.in
+++ b/kicadlibrarian.desktop.in
@@ -2,7 +2,7 @@
 Version=1.0
 Name=KiCad Librarian
 Comment=A library manager for KiCad
-Exec=/opt/kicadlibrarian/bin/kicadlibrarian
+Exec=${CMAKE_INSTALL_PREFIX}/bin/kicadlibrarian
 Icon=kicadlibrarian32
 Terminal=false
 Type=Application

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,8 +118,11 @@ SET(DEB_DESKTOP_DIR     "/usr/share/applications")
 SET(DEB_MIME_DIR        "/usr/share/mime/packages")
 SET(DEB_PIXMAPS_DIR     "/usr/share/pixmaps")
 
+configure_file(${CMAKE_SOURCE_DIR}/../kicadlibrarian.desktop.in
+	${CMAKE_BINARY_DIR}/kicadlibrarian.desktop
+	NEWLINE_STYLE UNIX)
 INSTALL(CODE "execute_process(COMMAND xdg-desktop-menu install --novendor
-	${CMAKE_SOURCE_DIR}/../kicadlibrarian.desktop OUTPUT_QUIET ERROR_QUIET)")
+	${CMAKE_BINARY_DIR}/kicadlibrarian.desktop OUTPUT_QUIET ERROR_QUIET)")
 INSTALL(CODE "execute_process(COMMAND xdg-icon-resource install --novendor --size 32
 	${CMAKE_SOURCE_DIR}/../kicadlibrarian32.png OUTPUT_QUIET ERROR_QUIET)")
 INSTALL(CODE "execute_process(COMMAND xdg-mime install --novendor

--- a/src/libmngr_frame.cpp
+++ b/src/libmngr_frame.cpp
@@ -907,7 +907,9 @@ void libmngrFrame::OnFootprintReport(wxCommandEvent& /*event*/)
     report.SetPage(format, (landscape != 0));
     report.FootprintOptions(opt_description != 0, opt_padinfo != 0, opt_labels != 0);
     report.SetFont(fontsize);
-    report.FootprintReport(this, library, modules, reportfile);
+    if(!report.FootprintReport(this, library, modules, reportfile)) {
+        return;
+    }
     m_statusBar->SetStatusText(wxT("Finished report"));
 
     #if wxMAJOR_VERSION < 3


### PR DESCRIPTION
Update kicadlibrarian.desktop at build time with the actual
location it will be installed to, and install this .desktop
file at install time.