### PR TITLE
fix menu IDs for Search Paths and About.

### DIFF
--- a/src/libmngr_gui_base.cpp
+++ b/src/libmngr_gui_base.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Oct 26 2018)
+// C++ code generated with wxFormBuilder (version Mar 22 2019)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO *NOT* EDIT THIS FILE!
@@ -94,7 +94,7 @@ AppFrame::AppFrame( wxWindow* parent, wxWindowID id, const wxString& title, cons
 
 	m_mnuPreferences = new wxMenu();
 	wxMenuItem* m_mnuSearchPaths;
-	m_mnuSearchPaths = new wxMenuItem( m_mnuPreferences, wxID_PREFERENCES, wxString( wxT("Search &Paths...") ) , wxT("Add or remove paths to search for footprint or symbol libraries"), wxITEM_NORMAL );
+	m_mnuSearchPaths = new wxMenuItem( m_mnuPreferences, IDM_PREFERENCES, wxString( wxT("Search &Paths...") ) , wxT("Add or remove paths to search for footprint or symbol libraries"), wxITEM_NORMAL );
 	m_mnuPreferences->Append( m_mnuSearchPaths );
 
 	wxMenuItem* m_mnuRemoteLink;
@@ -123,7 +123,7 @@ AppFrame::AppFrame( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	m_mnuHelp->Append( m_mnuHelpManual );
 
 	wxMenuItem* m_mnuAbout;
-	m_mnuAbout = new wxMenuItem( m_mnuHelp, wxID_ABOUT, wxString( wxT("&About") ) , wxEmptyString, wxITEM_NORMAL );
+	m_mnuAbout = new wxMenuItem( m_mnuHelp, IDM_ABOUT, wxString( wxT("&About") ) , wxEmptyString, wxITEM_NORMAL );
 	m_mnuHelp->Append( m_mnuAbout );
 
 	m_menubar->Append( m_mnuHelp, wxT("&Help") );

--- a/src/libmngr_gui_base.fbp
+++ b/src/libmngr_gui_base.fbp
@@ -14,6 +14,7 @@
         <property name="file">libmngr_gui_base</property>
         <property name="first_id">1000</property>
         <property name="help_provider">none</property>
+        <property name="image_path_wrapper_function_name"></property>
         <property name="indent_with_spaces"></property>
         <property name="internationalize">0</property>
         <property name="name">libmngr_gui</property>
@@ -25,9 +26,10 @@
         <property name="skip_php_events">1</property>
         <property name="skip_python_events">1</property>
         <property name="ui_table">UI</property>
+        <property name="use_array_enum">0</property>
         <property name="use_enum">0</property>
         <property name="use_microsoft_bom">0</property>
-        <object class="Frame" expanded="0">
+        <object class="Frame" expanded="1">
             <property name="aui_managed">0</property>
             <property name="aui_manager_style">wxAUI_MGR_DEFAULT</property>
             <property name="bg">wxSYS_COLOUR_MENU</property>
@@ -55,7 +57,7 @@
             <property name="window_style">wxTAB_TRAVERSAL</property>
             <property name="xrc_skip_sizer">1</property>
             <event name="OnClose">OnCloseApp</event>
-            <object class="wxMenuBar" expanded="0">
+            <object class="wxMenuBar" expanded="1">
                 <property name="bg"></property>
                 <property name="context_help"></property>
                 <property name="context_menu">1</property>
@@ -289,7 +291,7 @@
                         <event name="OnMenuSelection">OnFilterToggle</event>
                     </object>
                 </object>
-                <object class="wxMenu" expanded="0">
+                <object class="wxMenu" expanded="1">
                     <property name="label">&amp;Preferences</property>
                     <property name="name">m_mnuPreferences</property>
                     <property name="permission">protected</property>
@@ -298,7 +300,7 @@
                         <property name="checked">0</property>
                         <property name="enabled">1</property>
                         <property name="help">Add or remove paths to search for footprint or symbol libraries</property>
-                        <property name="id">wxID_PREFERENCES</property>
+                        <property name="id">IDM_PREFERENCES</property>
                         <property name="kind">wxITEM_NORMAL</property>
                         <property name="label">Search &amp;Paths...</property>
                         <property name="name">m_mnuSearchPaths</property>
@@ -368,7 +370,7 @@
                         <event name="OnMenuSelection">OnUIOptions</event>
                     </object>
                 </object>
-                <object class="wxMenu" expanded="0">
+                <object class="wxMenu" expanded="1">
                     <property name="label">&amp;Help</property>
                     <property name="name">m_mnuHelp</property>
                     <property name="permission">protected</property>
@@ -391,7 +393,7 @@
                         <property name="checked">0</property>
                         <property name="enabled">1</property>
                         <property name="help"></property>
-                        <property name="id">wxID_ABOUT</property>
+                        <property name="id">IDM_ABOUT</property>
                         <property name="kind">wxITEM_NORMAL</property>
                         <property name="label">&amp;About</property>
                         <property name="name">m_mnuAbout</property>

--- a/src/libmngr_gui_base.h
+++ b/src/libmngr_gui_base.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Oct 26 2018)
+// C++ code generated with wxFormBuilder (version Mar 22 2019)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO *NOT* EDIT THIS FILE!
@@ -56,30 +56,32 @@
 #define IDM_DETAILSPANEL 1008
 #define IDM_SYNCMODE 1009
 #define IDM_FILTER 1010
-#define IDM_DLGREMOTE 1011
-#define IDM_DLGREPORT 1012
-#define IDM_TEMPLATEOPTIONS 1013
-#define IDM_DLGOPTIONS 1014
-#define IDM_LEFT_LIB 1015
-#define IDM_LEFT_MOD 1016
-#define IDM_MOVEMODULE 1017
-#define IDM_COPYMODULE 1018
-#define IDM_DELETEMODULE 1019
-#define IDM_RENAMEMODULE 1020
-#define IDM_RIGHT_LIB 1021
-#define IDM_RIGHT_MOD 1022
-#define IDT_ZOOMIN 1023
-#define IDT_ZOOMOUT 1024
-#define IDT_3DVIEW 1025
-#define IDT_MEASUREMENTS 1026
-#define IDT_DETAILSPANEL 1027
-#define IDT_LEFTFOOTPRINT 1028
-#define IDT_RIGHTFOOTPRINT 1029
-#define IDM_PANELVIEW 1030
-#define IDC_PADSHAPE 1031
-#define IDC_BODYSHAPE 1032
-#define IDT_SAVE 1033
-#define IDT_REVERT 1034
+#define IDM_PREFERENCES 1011
+#define IDM_DLGREMOTE 1012
+#define IDM_DLGREPORT 1013
+#define IDM_TEMPLATEOPTIONS 1014
+#define IDM_DLGOPTIONS 1015
+#define IDM_ABOUT 1016
+#define IDM_LEFT_LIB 1017
+#define IDM_LEFT_MOD 1018
+#define IDM_MOVEMODULE 1019
+#define IDM_COPYMODULE 1020
+#define IDM_DELETEMODULE 1021
+#define IDM_RENAMEMODULE 1022
+#define IDM_RIGHT_LIB 1023
+#define IDM_RIGHT_MOD 1024
+#define IDT_ZOOMIN 1025
+#define IDT_ZOOMOUT 1026
+#define IDT_3DVIEW 1027
+#define IDT_MEASUREMENTS 1028
+#define IDT_DETAILSPANEL 1029
+#define IDT_LEFTFOOTPRINT 1030
+#define IDT_RIGHTFOOTPRINT 1031
+#define IDM_PANELVIEW 1032
+#define IDC_PADSHAPE 1033
+#define IDC_BODYSHAPE 1034
+#define IDT_SAVE 1035
+#define IDT_REVERT 1036
 
 ///////////////////////////////////////////////////////////////////////////////
 /// Class AppFrame


### PR DESCRIPTION
Search Paths and About had IDs in the .fbp file that started with wxID. On macOS these IDs caused the menus to appear underneath the "kicadlibrarian" menu (to the left of File). They were also non-functional. Giving them their own IDs using wxFormBuilder fixed the problem.